### PR TITLE
fix(ux) - Add sufficient padding in notes

### DIFF
--- a/src/pages/NoteDetails.tsx
+++ b/src/pages/NoteDetails.tsx
@@ -231,7 +231,7 @@ const NoteDetails: React.FC<NoteDetailsPageProps> = ({match}) => {
       </IonHeader>
       <IonContent fullscreen>
         <NoteTitle title={note.title} update={updateNoteTitle} />
-        <div id="openDescriptionEditModal" style={{padding: '0 16px 24px', height: "100%"}}>
+        <div id="openDescriptionEditModal" style={{padding: '0 16px 24px'}}>
           <Markdown>
             {note.description}
           </Markdown>

--- a/src/pages/NoteDetails.tsx
+++ b/src/pages/NoteDetails.tsx
@@ -231,7 +231,7 @@ const NoteDetails: React.FC<NoteDetailsPageProps> = ({match}) => {
       </IonHeader>
       <IonContent fullscreen>
         <NoteTitle title={note.title} update={updateNoteTitle} />
-        <div id="openDescriptionEditModal" style={{padding: '0 16px', height: "100%"}}>
+        <div id="openDescriptionEditModal" style={{padding: '0 16px 24px', height: "100%"}}>
           <Markdown>
             {note.description}
           </Markdown>


### PR DESCRIPTION
When viewing a note, oftentimes it ends abruptly because there is no padding at the end of the note. This is especially apparent when viewing a longer note, and the user is unsure whether there is more to the note or not.

Add some extra padding at the bottom to allow for a better UX.