### PR TITLE
feat(ux): Add overlay behind expanded fab

### DIFF
--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,6 +1,6 @@
-import { IonActionSheet, IonButton, IonButtons, IonCol, IonContent, IonFab, IonFabButton, IonFabList, IonGrid, IonHeader, IonIcon, IonPage, IonRow, IonTitle, IonToolbar, isPlatform, useIonRouter, useIonToast, useIonViewDidEnter, useIonViewWillEnter } from '@ionic/react';
+import { IonActionSheet, IonBackdrop, IonButton, IonButtons, IonCol, IonContent, IonFab, IonFabButton, IonFabList, IonGrid, IonHeader, IonIcon, IonPage, IonRow, IonTitle, IonToolbar, isPlatform, useIonRouter, useIonToast, useIonViewDidEnter, useIonViewWillEnter } from '@ionic/react';
 import './Home.css';
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import PouchDB from 'pouchdb'
 import PouchFind from 'pouchdb-find'
 import CordovaSqlite from 'pouchdb-adapter-cordova-sqlite'
@@ -284,6 +284,8 @@ const Home: React.FC = () => {
   const router = useIonRouter()
   const [homeUI, setHomeUI] = useState("list")
   const [appInfo, setAppInfo] = useState<AppInfo>()
+  const fabRef = useRef<HTMLIonFabElement>(null)
+  const [overlayVisible, setOverlayVisible] = useState(false)
 
   if(isPlatform('android')) {
     document.addEventListener('ionBackButton', (ev) => {
@@ -311,6 +313,10 @@ const Home: React.FC = () => {
 
   return (
     <IonPage>
+      <IonBackdrop
+        visible={overlayVisible}
+        style={{opacity: 0.15, zIndex: overlayVisible ? 11 : -1, transition: 'opacity,background 0.25s ease-in-out'}}
+      ></IonBackdrop>
       <IonHeader className='ion-no-border'>
         <IonToolbar>
           <IonTitle>Duet</IonTitle>
@@ -358,7 +364,7 @@ const Home: React.FC = () => {
           }}
         ></IonActionSheet>
         <ReloadPrompt />
-        <IonFab slot='fixed' vertical='bottom' horizontal='end'>
+        <IonFab ref={fabRef} onClick={() => {fabRef.current?.activated ? setOverlayVisible(true) : setOverlayVisible(false)}} slot='fixed' vertical='bottom' horizontal='end'>
           <IonFabButton>
             <IonIcon icon={addSharp}></IonIcon>
           </IonFabButton>

--- a/src/pages/ProjectDetails.tsx
+++ b/src/pages/ProjectDetails.tsx
@@ -1,4 +1,4 @@
-import { IonBackButton, IonButton, IonButtons, IonCheckbox, IonContent, IonFab, IonFabButton, IonFabList, IonHeader, IonIcon, IonItem, IonLabel, IonList, IonListHeader, IonPage, IonTextarea, IonToolbar, isPlatform, useIonViewDidEnter } from "@ionic/react"
+import { IonBackButton, IonBackdrop, IonButton, IonButtons, IonCheckbox, IonContent, IonFab, IonFabButton, IonFabList, IonHeader, IonIcon, IonItem, IonLabel, IonList, IonListHeader, IonPage, IonTextarea, IonToolbar, isPlatform, useIonViewDidEnter } from "@ionic/react"
 import { RouteComponentProps } from "react-router"
 import PouchDB from "pouchdb"
 import PouchFind from "pouchdb-find"
@@ -31,6 +31,8 @@ const ProjectDetailsPage: React.FC<ProjectDetailsPageProps> = ({match}) => {
   const [projectNotes, setProjectNotes] = useState([])
   const [completedProjectTasks, setCompletedProjectTasks] = useState([])
   const [showCompleted, setShowCompleted] = useState(false)
+  const [overlayVisible, setOverlayVisible] = useState(false)
+  const fabRef = useRef<HTMLIonFabElement>(null)
 
   const [description, setDescription] = useState("")
 
@@ -126,6 +128,10 @@ const ProjectDetailsPage: React.FC<ProjectDetailsPageProps> = ({match}) => {
 
   return (
     <IonPage>
+      <IonBackdrop
+        visible={overlayVisible}
+        style={{opacity: 0.15, zIndex: overlayVisible ? 11 : -1, transition: 'opacity,background 0.25s ease-in-out'}}
+      ></IonBackdrop>
       <IonHeader className="ion-no-border">
         <IonToolbar>
           <IonButtons slot='start'>
@@ -235,7 +241,7 @@ const ProjectDetailsPage: React.FC<ProjectDetailsPageProps> = ({match}) => {
           }
         </div>
 
-        <IonFab slot='fixed' vertical='bottom' horizontal='end'>
+        <IonFab ref={fabRef} onClick={() => {fabRef.current?.activated ? setOverlayVisible(true) : setOverlayVisible(false)}} slot='fixed' vertical='bottom' horizontal='end'>
           <IonFabButton>
             <IonIcon icon={add}></IonIcon>
           </IonFabButton>


### PR DESCRIPTION
When an FAB is expanded and has child items, it is not evident to the user that the FAB is opened or that any activity has taken place. An overlay behind the FAB helps direct the user to the expanded FAB and take the relevant next action.