### PR TITLE
feat(ux): Add FAB item labels

### DIFF
--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -10,6 +10,7 @@ import { App, AppInfo } from '@capacitor/app';
 import { Preferences } from '@capacitor/preferences';
 import HomeCardsUI from '../components/Home/CardsUI';
 import HomeListUI from '../components/Home/ListUI';
+import "./fab.css"
 
 const Home: React.FC = () => {
 
@@ -369,10 +370,10 @@ const Home: React.FC = () => {
             <IonIcon icon={addSharp}></IonIcon>
           </IonFabButton>
           <IonFabList side='top'>
-            <IonFabButton routerLink="/add-task">
+            <IonFabButton routerLink="/add-task" data-title="Add to Inbox">
               <IonIcon icon={fileTraySharp}></IonIcon>
             </IonFabButton>
-            <IonFabButton routerLink="/notes/add">
+            <IonFabButton routerLink="/notes/add" data-title="Add note">
               <IonIcon icon={documentTextSharp}></IonIcon>
             </IonFabButton>
           </IonFabList>

--- a/src/pages/ProjectDetails.tsx
+++ b/src/pages/ProjectDetails.tsx
@@ -10,6 +10,7 @@ import TaskItem from "../components/Tasks/TaskItem"
 import NoteItem from "../components/Notes/NoteItem"
 import Markdown from "react-markdown"
 import Title from "../components/Title/Title"
+import "./fab.css"
 
 interface ProjectDetailsPageProps extends RouteComponentProps<{
   id: string
@@ -246,10 +247,10 @@ const ProjectDetailsPage: React.FC<ProjectDetailsPageProps> = ({match}) => {
             <IonIcon icon={add}></IonIcon>
           </IonFabButton>
           <IonFabList side="top">
-            <IonFabButton routerLink={"/project/add-task/" + match.params.id}>
+            <IonFabButton routerLink={"/project/add-task/" + match.params.id} data-title="Add task">
               <IonIcon icon={checkmarkSharp}></IonIcon>
             </IonFabButton>
-            <IonFabButton routerLink={"/notes/add/" + match.params.id}>
+            <IonFabButton routerLink={"/notes/add/" + match.params.id} data-title="Add note">
               <IonIcon icon={documentTextSharp}></IonIcon>
             </IonFabButton>
           </IonFabList>

--- a/src/pages/fab.css
+++ b/src/pages/fab.css
@@ -1,0 +1,18 @@
+ion-fab-button[data-title] {
+  position: relative;
+}
+
+ion-fab-button[data-title]::after {
+  position: absolute;
+  content: attr(data-title);
+  z-index: 1;
+  right: 55px;
+  top: 50%;
+  transform: translateY(-50%);
+  background-color: var(--ion-color-light);
+  padding: 6px 16px;
+  border-radius: 4px;
+  color: rgba(var(--ion-text-color-rgb, 0, 0, 0), 0.54);
+  box-shadow: 0 3px 5px -1px rgba(0, 0, 0, 0.2), 0 6px 10px 0 rgba(0, 0, 0, 0.14), 0 1px 18px 0 rgba(0, 0, 0, 0.12);
+  transition: box-shadow 280ms cubic-bezier(0.4, 0, 0.2, 1), background-color 280ms cubic-bezier(0.4, 0, 0.2, 1), color 280ms cubic-bezier(0.4, 0, 0.2, 1), opacity 15ms linear 30ms, transform 270ms cubic-bezier(0, 0, 0.2, 1) 0ms;
+}


### PR DESCRIPTION
For expanded FAB items, add a label so that users will know what each button does without having to guess what they do.