### PR TITLE
fix(core): Fix status picker in task list failing

### DIFF
--- a/src/components/Tasks/TaskItem.tsx
+++ b/src/components/Tasks/TaskItem.tsx
@@ -1,13 +1,22 @@
-import { IonIcon, IonItem, IonLabel, IonRippleEffect, useIonModal, useIonRouter } from "@ionic/react";
+import { IonIcon, IonItem, IonLabel, IonRippleEffect, isPlatform, useIonModal, useIonRouter } from "@ionic/react";
 import { checkmarkCircle, chevronForwardCircleOutline, ellipseOutline, pauseCircleOutline, removeCircle } from "ionicons/icons";
 import StatusPickerModal from "./StatusPickerModal";
 import { OverlayEventDetail } from "@ionic/react/dist/types/components/react-component-lib/interfaces";
 import PouchDB from "pouchdb"
 import PouchFind from "pouchdb-find"
+import CordovaSqlite from "pouchdb-adapter-cordova-sqlite"
 
 const TaskItem: React.FC<TaskItemProps> = (props) => {
 
-  const db = new PouchDB('duet');
+  let db: PouchDB.Database
+  if(isPlatform('capacitor')) {
+    document.addEventListener('deviceready', () => {
+      PouchDB.plugin(CordovaSqlite)
+      db = new PouchDB('duet', {adapter: "cordova-sqlite"});
+    })
+  } else {
+    db = new PouchDB('duet');
+  }
 
   const { task, updateFn, project } = props
 


### PR DESCRIPTION
Picking a status from the status picker in the task list would do nothing. This was because it would fail silently since the TaskItem component wasn't updated to use the SQLite adapter on Capacitor instead of IndexedDB. This commit fixes the regression, and status updates from the task list should work as expected now.