### PR TITLE
feat(ux): Update note & task titles on keyboard hide

### DIFF
--- a/src/components/NoteTitle/NoteTitle.tsx
+++ b/src/components/NoteTitle/NoteTitle.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState } from "react"
 import './NoteTitle.css'
+import { Keyboard } from "@capacitor/keyboard"
 
 const NoteTitle = ({ title, update } : {title: string, update: (title: string) => void}) => {
 
@@ -9,6 +10,12 @@ const NoteTitle = ({ title, update } : {title: string, update: (title: string) =
 
   useEffect(() => {
     setContent(title)
+
+    Keyboard.addListener('keyboardWillHide', () => {
+      if(document.activeElement === inputRef.current!) {
+        inputRef.current!.blur()
+      }
+    })
   }, [])
 
   useEffect(() => {
@@ -61,6 +68,7 @@ const NoteTitle = ({ title, update } : {title: string, update: (title: string) =
             }
           }}
           onBlur={(e) => {
+            update(content)
             setIsEditing(false)
           }}
         >{title ?? ""}</textarea>

--- a/src/components/Title/Title.tsx
+++ b/src/components/Title/Title.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState } from "react"
 import './Title.css'
+import { Keyboard } from "@capacitor/keyboard"
 
 const Title = ({ title, update } : {title: string, update: (title: string) => void}) => {
 
@@ -9,6 +10,12 @@ const Title = ({ title, update } : {title: string, update: (title: string) => vo
 
   useEffect(() => {
     setContent(title)
+
+    Keyboard.addListener('keyboardWillHide', () => {
+      if(document.activeElement === inputRef.current!) {
+        inputRef.current!.blur()
+      }
+    })
   }, [])
 
   useEffect(() => {
@@ -61,6 +68,7 @@ const Title = ({ title, update } : {title: string, update: (title: string) => vo
             }
           }}
           onBlur={(e) => {
+            update(content)
             setIsEditing(false)
           }}
         >{title ?? ""}</textarea>


### PR DESCRIPTION
Instead of requiring the user to press a confirm button on the keyboard (check mark on virtual keyboards on mobile devices, or enter key on a desktop), update the task or note title when a blur event occurs - such as hiding of the virtual keyboard on mobile devices, or pressing tab to go to the next field on desktop devices.