### PR TITLE
fix(ux): Fix UI blink on updating task or project

### DIFF
--- a/src/pages/ProjectDetails.tsx
+++ b/src/pages/ProjectDetails.tsx
@@ -88,6 +88,7 @@ const ProjectDetailsPage: React.FC<ProjectDetailsPageProps> = ({match}) => {
   }
 
   const updateProjectTitle = async (title: string) => {
+    setProject({...project, title: title})
     const timestamp = new Date().toISOString()
     
     const response = await db.put({

--- a/src/pages/TaskDetails.tsx
+++ b/src/pages/TaskDetails.tsx
@@ -174,6 +174,7 @@ const TaskDetails: React.FC<TaskDetailsPageProps> = ({match}) => {
   }
 
   const updateTaskDescription = async (description: string) => {
+    setTask({...task, description: description})
     const timestamp = new Date().toISOString()
     
     const response = await db.put({
@@ -192,6 +193,7 @@ const TaskDetails: React.FC<TaskDetailsPageProps> = ({match}) => {
   }
 
   const updateTaskTitle = async (title: string) => {
+    setTask({...task, title: title})
     const timestamp = new Date().toISOString()
     
     const response = await db.put({


### PR DESCRIPTION
When updating the titles or descriptions of tasks or projects, the UI would "blink" and look glitchy to the user. Alleviate this by setting the state for the titles and descriptions before saving to the DB so that there is no UI blink.