### PR TITLE
fix(ui): Show loading spinner only on initial fetch from DB in Projects screen

### DIFF
--- a/src/pages/Projects.tsx
+++ b/src/pages/Projects.tsx
@@ -46,6 +46,9 @@ const ProjectsPage: React.FC = () => {
         if(result.rows) {
           console.log(result)
           setProjectsProgress(result.rows)
+          if(!initiallyFetched) {
+            setInitiallyFetched(true)
+          }
           setFetched(true)
         }
       }).catch((err: Error) => {
@@ -59,8 +62,9 @@ const ProjectsPage: React.FC = () => {
   const [projects, setProjects] = useState([])
   const [projectsProgress, setProjectsProgress] = useState([])
   const [fetched, setFetched] = useState(false)
+  const [initiallyFetched, setInitiallyFetched] = useState(false)
 
-  if(!fetched) {
+  if(!fetched && !initiallyFetched) {
     return (
       <IonPage>
         <IonHeader className="ion-no-border">


### PR DESCRIPTION
Show the loading progress bar only on the initial fetch on the Projects screen. This ensures that there is no UI blink when the user returns to the projects screen after viewing a project.