### PR TITLE
feat(ui): Add experimental multi-pane support

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,6 +9,7 @@ import TagsPage from './pages/Tags';
 import ProjectsPage from './pages/Projects';
 import AddProject from './pages/AddProject';
 import AddTask from './pages/AddTask';
+import useScreenSize from './hooks/useScreenSize';
 
 /* Core CSS required for Ionic components to work properly */
 import '@ionic/react/css/core.css';
@@ -54,6 +55,7 @@ import ReloadPrompt from './components/ReloadPrompt';
 import Actionable from './pages/Actionable';
 import NotesFolderPage from './pages/NotesFolder';
 import Waiting from './pages/Waiting';
+import ThreePaneUI from './components/ThreePaneUI';
 
 setupIonicReact({
   mode: 'md'
@@ -79,64 +81,71 @@ async function setStatusBarStyleLight() {
   })
 };
 
-const App: React.FC = () => (
-  <IonApp>
-    <IonReactRouter>
-      <IonRouterOutlet>
-        <Route exact path="/home">
-          <Home />
-        </Route>
-        <Route exact path="/today">
-          <Today />
-        </Route>
-        <Route exact path="/actionable">
-          <Actionable />
-        </Route>
-        <Route exact path="/upcoming">
-          <Upcoming />
-        </Route>
-        <Route exact path="/waiting">
-          <Waiting />
-        </Route>
-        <Route exact path="/project">
-          <ProjectsPage />
-        </Route>
-        <Route exact path="/project/add">
-          <AddProject />
-        </Route>
-        <Route exact path="/project/details/:id" component={ProjectDetailsPage}/>
-        <Route path="/project/add-task/:id">
-          <AddTask />
-        </Route>
-        <Route exact path="/tags">
-          <TagsPage />
-        </Route>
-        <Route path="/tasks/:id" component={TaskDetails}/>
-        <Route exact path="/inbox">
-          <Inbox />
-        </Route>
-        <Route exact path="/notes">
-          <NotesPage />
-        </Route>
-        <Route exact path="/notes/add" component={AddNote} />
-        <Route exact path="/notes/add/:id" component={AddNote} />
-        <Route path="/notes/details/:id" component={NoteDetails} />
-        <Route path="/notes/folder/:path" component={NotesFolderPage} />
-        <Route exact path="/logbook">
-          <LogbookPage />
-        </Route>
-        <Route exact path="/add-task">
-          <AddTask />
-        </Route>
-        <Route exact path="/settings">
-          <SettingsPage />
-        </Route>
-        <Route exact path="/">
-          <Redirect to="/home" />
-        </Route>
-      </IonRouterOutlet>
-    </IonReactRouter>
-  </IonApp>
-);
+const App: React.FC = () => {
+
+  const screenSize = useScreenSize()
+
+  return (
+    <IonApp>
+      <IonReactRouter>
+        {
+          screenSize.width > 992
+          ? <ThreePaneUI />
+          :
+          <IonRouterOutlet>
+            {/* <Route exact path="/home" component={Home}>
+            </Route> */}
+            <Route exact path="/" component={Home}>
+            </Route>
+            <Route exact path="/today" component={Today} />
+            <Route exact path="/actionable" component={Actionable} />
+            <Route exact path="/upcoming" component={Upcoming} />
+            <Route exact path="/waiting" component={Waiting} />
+            {/* <Route exact path="/project">
+              <ProjectsPage />
+            </Route> */}
+            <Route path="/project" render={() => <ProjectsPage />} />
+            <Route exact path="/project/add">
+              <AddProject />
+            </Route>
+            <Route exact path="/project/details/:id" component={ProjectDetailsPage}/>
+            <Route path="/project/add-task/:id">
+              <AddTask />
+            </Route>
+            <Route exact path="/tags">
+              <TagsPage />
+            </Route>
+            <Route path="/tasks/:id" component={TaskDetails}/>
+            <Route exact path="/inbox" component={Inbox} />
+            <Route exact path="/inbox/:id" component={TaskDetails} />
+            <Route exact path="/actionable/:id" component={TaskDetails} />
+            <Route exact path="/waiting/:id" component={TaskDetails} />
+            <Route exact path="/upcoming/:id" component={TaskDetails} />
+            <Route exact path="/today/:id" component={TaskDetails} />
+            <Route exact path="/notes">
+              <NotesPage />
+            </Route>
+            <Route exact path="/notes/add" component={AddNote} />
+            <Route exact path="/notes/add/:id" component={AddNote} />
+            <Route path="/notes/details/:id" component={NoteDetails} />
+            <Route path="/notes/folder/:path" component={NotesFolderPage} />
+            <Route exact path="/logbook">
+              <LogbookPage />
+            </Route>
+            <Route exact path="/add-task">
+              <AddTask />
+            </Route>
+            <Route exact path="/settings">
+              <SettingsPage />
+            </Route>
+            {/* <Route exact path="/">
+              <Redirect to="/home" />
+            </Route> */}
+          </IonRouterOutlet>
+        }
+      </IonReactRouter>
+    </IonApp>
+  )
+}
 
 export default App;

--- a/src/components/Home/ListUI.tsx
+++ b/src/components/Home/ListUI.tsx
@@ -1,29 +1,30 @@
-import { IonButton, IonIcon, IonItem, IonLabel, IonList, IonListHeader } from "@ionic/react"
+import { IonButton, IonIcon, IonItem, IonLabel, IonList, IonListHeader, useIonRouter } from "@ionic/react"
 import { calendarSharp, checkmarkCircleSharp, fileTraySharp, pauseCircleSharp, starSharp } from "ionicons/icons"
 import ProjectsTile from "./List/Projects"
 import NotesTile from "./List/Notes"
 
 const HomeListUI = () => {
+  const router = useIonRouter()
   return (
     <>
       <IonList>
-        <IonItem button routerLink="/inbox">
+        <IonItem className={router.routeInfo.pathname.includes("inbox") ? "active" : ""} button routerLink={(window.innerWidth > 992) ? "/inbox" : "/inbox"} >
           <IonIcon slot="start" style={{color: '#2196F3'}} icon={fileTraySharp} />
           <IonLabel>Inbox</IonLabel>
         </IonItem>
-        <IonItem button routerLink="/today">
+        <IonItem className={router.routeInfo.pathname.includes("today") ? "active" : ""} button routerLink={(window.innerWidth > 992) ? "/today" : "/today"}>
           <IonIcon slot="start" style={{color: '#F9A825'}} icon={starSharp} />
           <IonLabel>Today</IonLabel>
         </IonItem>
-        <IonItem button routerLink="/actionable">
+        <IonItem className={router.routeInfo.pathname.includes("actionable") ? "active" : ""} button routerLink="/actionable">
           <IonIcon slot="start" style={{color: '#689F38'}} icon={checkmarkCircleSharp} />
           <IonLabel>Actionable</IonLabel>
         </IonItem>
-        <IonItem button routerLink="/waiting">
+        <IonItem className={router.routeInfo.pathname.includes("waiting") ? "active" : ""} button routerLink="/waiting">
           <IonIcon slot="start" color="medium" icon={pauseCircleSharp} />
           <IonLabel>Waiting for</IonLabel>
         </IonItem>
-        <IonItem button lines="none" routerLink="/upcoming">
+        <IonItem className={router.routeInfo.pathname.includes("upcoming") ? "active" : ""} button lines="none" routerLink="/upcoming">
           <IonIcon slot="start" style={{color: '#F44336'}} icon={calendarSharp} />
           <IonLabel>Upcoming</IonLabel>
         </IonItem>

--- a/src/components/Tasks/TaskItem.tsx
+++ b/src/components/Tasks/TaskItem.tsx
@@ -18,7 +18,7 @@ const TaskItem: React.FC<TaskItemProps> = (props) => {
     db = new PouchDB('duet');
   }
 
-  const { task, updateFn, project } = props
+  const { task, updateFn, project, url } = props
 
   const router = useIonRouter()
 
@@ -81,7 +81,7 @@ const TaskItem: React.FC<TaskItemProps> = (props) => {
   }
   
   return (
-    <IonItem className="task-item" key={task._id} button onClick={() => {router.push("/tasks/" + task._id)}}>
+    <IonItem className={"task-item " + ( router?.routeInfo.pathname.split("/").at(-1) === task._id ? "active" : "" )} key={task._id} button onClick={() => {router.push(url! + "/" + task._id)}}>
       <div slot="start" className="status-wrapper ion-activatable" onClick={(e) => {openModal(task._id); e.stopPropagation()}}>
         <IonRippleEffect type="unbounded"></IonRippleEffect>
         <IonIcon icon={icons[task.status].icon} onClick={() => {}} color={icons[task.status].color}></IonIcon>

--- a/src/components/ThreePaneUI.tsx
+++ b/src/components/ThreePaneUI.tsx
@@ -1,0 +1,15 @@
+import { IonRouterOutlet } from "@ionic/react"
+import { Route } from "react-router"
+import Home from "../pages/Home"
+
+const ThreePaneUI: React.FC = () => {
+  return (
+    <>
+      <IonRouterOutlet>
+        <Route path="/" component={Home} />
+      </IonRouterOutlet>
+    </>
+  )
+}
+
+export default ThreePaneUI

--- a/src/hooks/useScreenSize.ts
+++ b/src/hooks/useScreenSize.ts
@@ -1,0 +1,27 @@
+import { useState, useEffect } from 'react';
+
+const useScreenSize = () => {
+  const [screenSize, setScreenSize] = useState({
+    width: window.innerWidth,
+    height: window.innerHeight,
+  });
+
+  useEffect(() => {
+    const handleResize = () => {
+      setScreenSize({
+        width: window.innerWidth,
+        height: window.innerHeight,
+      });
+    };
+
+    window.addEventListener('resize', handleResize);
+
+    return () => {
+      window.removeEventListener('resize', handleResize);
+    };
+  }, []);
+
+  return screenSize;
+};
+
+export default useScreenSize;

--- a/src/main.css
+++ b/src/main.css
@@ -6,6 +6,14 @@ ion-list.md {
   background: transparent;
 }
 
+ion-item.md.active::part(native) {
+  background: var(--ion-background-color-step-50);
+}
+
+ion-list.md.active {
+  background: transparent;
+}
+
 ion-modal.statusPickerModal {
   --width: max-content;
   --min-width: 300px;

--- a/src/pages/Actionable.tsx
+++ b/src/pages/Actionable.tsx
@@ -4,11 +4,11 @@ import { useEffect, useRef, useState } from "react";
 import PouchDB from "pouchdb"
 import PouchFind from "pouchdb-find"
 import CordovaSqlite from 'pouchdb-adapter-cordova-sqlite'
-import { useHistory } from "react-router";
+import { RouteComponentProps, useHistory } from "react-router";
 import TaskItem from "../components/Tasks/TaskItem";
 import TasksSkeletonLoader from "../components/TasksSkeletonLoader";
 
-const Actionable: React.FC = () => {
+const Actionable: React.FC<RouteComponentProps> = ({match}) => {
 
   let db: PouchDB.Database
   if(isPlatform('capacitor')) {
@@ -139,7 +139,7 @@ const Actionable: React.FC = () => {
             {
               filteredActionableTasks.map(task => {
                 return (
-                  <TaskItem key={task._id} task={task} updateFn={getActionableTasks} project={task.project_id ? projects.find(p => p._id == task.project_id) : null} />
+                  <TaskItem key={task._id} task={task} updateFn={getActionableTasks} project={task.project_id ? projects.find(p => p._id == task.project_id) : null} url={match?.url} />
                 )
               })
             }

--- a/src/pages/Inbox.tsx
+++ b/src/pages/Inbox.tsx
@@ -1,4 +1,4 @@
-import { IonBackButton, IonButton, IonButtons, IonCheckbox, IonCol, IonContent, IonFab, IonFabButton, IonGrid, IonHeader, IonIcon, IonInput, IonItem, IonLabel, IonList, IonModal, IonPage, IonRippleEffect, IonRow, IonSkeletonText, IonSpinner, IonText, IonTitle, IonToolbar, isPlatform, useIonModal, useIonRouter, useIonViewDidEnter } from "@ionic/react"
+import { IonBackButton, IonButton, IonButtons, IonCheckbox, IonCol, IonContent, IonFab, IonFabButton, IonGrid, IonHeader, IonIcon, IonInput, IonItem, IonLabel, IonList, IonModal, IonPage, IonRippleEffect, IonRouterOutlet, IonRow, IonSkeletonText, IonSpinner, IonText, IonTitle, IonToolbar, isPlatform, useIonModal, useIonRouter, useIonViewDidEnter } from "@ionic/react"
 import { add, checkmarkCircle, chevronForwardCircle, closeCircle, closeCircleOutline, ellipseOutline, pauseCircle } from "ionicons/icons";
 import { useEffect, useRef, useState } from "react";
 import PouchDB from "pouchdb"
@@ -9,8 +9,10 @@ import '../taskList.css'
 import { OverlayEventDetail } from "@ionic/react/dist/types/components/react-component-lib/interfaces";
 import TaskItem from "../components/Tasks/TaskItem";
 import TasksSkeletonLoader from "../components/TasksSkeletonLoader";
+import { Route, RouteComponentProps } from "react-router";
+import TaskDetails from "./TaskDetails";
 
-const Inbox: React.FC = () => {
+const Inbox: React.FC<RouteComponentProps> = ({match}) => {
 
   let db: PouchDB.Database
 
@@ -87,19 +89,17 @@ const Inbox: React.FC = () => {
             {
               inboxTasks.map(task => {
                 return (
-                  <TaskItem key={task._id} task={task} updateFn={getInboxTasks} />
+                  <TaskItem key={task._id} task={task} updateFn={getInboxTasks} url={match?.url} />
                 )
               })
             }
           </IonList>
         }
-
         <IonFab slot='fixed' vertical='bottom' horizontal='end'>
           <IonFabButton routerLink="/add-task">
             <IonIcon icon={add}></IonIcon>
           </IonFabButton>
         </IonFab>
-
       </IonContent>
     </IonPage>
   )

--- a/src/pages/ProjectDetails.tsx
+++ b/src/pages/ProjectDetails.tsx
@@ -1,5 +1,5 @@
-import { IonActionSheet, IonAlert, IonBackButton, IonBackdrop, IonButton, IonButtons, IonCheckbox, IonContent, IonFab, IonFabButton, IonFabList, IonHeader, IonIcon, IonItem, IonLabel, IonList, IonListHeader, IonPage, IonText, IonTextarea, IonToolbar, isPlatform, useIonRouter, useIonViewDidEnter } from "@ionic/react"
-import { RouteComponentProps } from "react-router"
+import { IonActionSheet, IonAlert, IonBackButton, IonBackdrop, IonButton, IonButtons, IonCheckbox, IonContent, IonFab, IonFabButton, IonFabList, IonHeader, IonIcon, IonItem, IonLabel, IonList, IonListHeader, IonPage, IonRouterOutlet, IonText, IonTextarea, IonToolbar, isPlatform, useIonRouter, useIonViewDidEnter } from "@ionic/react"
+import { Route, RouteComponentProps } from "react-router"
 import PouchDB from "pouchdb"
 import PouchFind from "pouchdb-find"
 import CordovaSqlite from "pouchdb-adapter-cordova-sqlite"
@@ -11,6 +11,7 @@ import NoteItem from "../components/Notes/NoteItem"
 import Markdown from "react-markdown"
 import Title from "../components/Title/Title"
 import "./fab.css"
+import TaskDetails from "./TaskDetails"
 
 interface ProjectDetailsPageProps extends RouteComponentProps<{
   id: string
@@ -193,229 +194,236 @@ const ProjectDetailsPage: React.FC<ProjectDetailsPageProps> = ({match}) => {
   }
 
   return (
-    <IonPage>
-      <IonBackdrop
-        visible={overlayVisible}
-        style={{opacity: 0.15, zIndex: overlayVisible ? 11 : -1, transition: 'opacity,background 0.25s ease-in-out'}}
-      ></IonBackdrop>
-      <IonHeader className="ion-no-border">
-        <IonToolbar>
-          <IonButtons slot='start'>
-            <IonBackButton defaultHref='/'></IonBackButton>
-          </IonButtons>
-          <IonButtons slot="end">
-            <IonButton id="openProjectActionsSheet">
-              <IonIcon slot="icon-only" icon={ellipsisVerticalSharp}></IonIcon>
-            </IonButton>
-          </IonButtons>
-        </IonToolbar>
-      </IonHeader>
-      <IonContent fullscreen>
-        {
-          project && project.status == "Archived" && project.status != "Completed"
-          ?  <div style={{display: 'flex', alignItems: 'center', justifyContent: 'center', gap: '4px', padding: '4px', textAlign: 'center', background: 'var(--ion-color-light-shade)', color: 'var(--ion-color-medium)', fontSize: '0.8rem', lineHeight: 1}}>
-            <IonIcon style={{fontSize: '0.79rem'}} icon={archiveSharp} color="medium"></IonIcon>
-            <IonLabel style={{lineHeight: 1.2}}>Archived</IonLabel>
-          </div>
-          : null
-        }
-        {
-          project && project.status == "Completed"
-          ?  <div style={{display: 'flex', alignItems: 'center', justifyContent: 'center', gap: '4px', padding: '4px', textAlign: 'center', background: 'rgba(var(--ion-color-success-rgb), 0.7)', color: 'var(--ion-color-success-contrast)', fontSize: '0.8rem', lineHeight: 1}}>
-            <IonIcon style={{fontSize: '0.79rem'}} icon={checkmarkCircleSharp} color="light-shade"></IonIcon>
-            <IonLabel style={{lineHeight: 1.2}}>Completed</IonLabel>
-          </div>
-          : null
-        }
-        <div style={{padding: '16px 16px 0'}}>
-          {/* <h3>{project.title}</h3> */}
-          <Title title={project.title} update={updateProjectTitle} />
-          {
-            !projectDescEditing
-            ? <div
-              style={{color: project.description ? 'initial' : 'var(--ion-color-medium)'}}
-              onClick={() => {
-                setProjectDescEditing(true)
-              }}
-            >
-              <Markdown
-              >
-                {project.description ? project.description : 'Tap to set a description'}
-              </Markdown>
-            </div>
-            : <div style={{display: 'flex', flexDirection: 'column', alignItems: 'flex-end', gap: 8}}>
-              <IonTextarea ref={projectDescEditor} value={description} onIonInput={(e) => {setDescription(e.detail.value!)}} aria-label="Description" placeholder="Enter description" autoGrow={true} rows={1}></IonTextarea>
-              <IonButton size="small" onClick={updateProjectDescription}>
-                <IonIcon slot="icon-only" icon={checkmarkSharp}></IonIcon>
-              </IonButton>
-            </div>
-          }
-        </div>
-
-        {
-          projectTasks.length > 0
-          ? <IonList style={{marginTop: 32}}>
+    <>
+      <div style={{width: router.routeInfo.pathname.includes("tasks") ? '33vw': '67vw'}}>
+        <IonPage style={{width: router.routeInfo.pathname.includes("tasks") ? '33vw': '67vw'}}>
+          <IonBackdrop
+            visible={overlayVisible}
+            style={{opacity: 0.15, zIndex: overlayVisible ? 11 : -1, transition: 'opacity,background 0.25s ease-in-out'}}
+          ></IonBackdrop>
+          <IonHeader className="ion-no-border">
+            <IonToolbar>
+              <IonButtons slot='start'>
+                <IonBackButton defaultHref='/'></IonBackButton>
+              </IonButtons>
+              <IonButtons slot="end">
+                <IonButton id="openProjectActionsSheet">
+                  <IonIcon slot="icon-only" icon={ellipsisVerticalSharp}></IonIcon>
+                </IonButton>
+              </IonButtons>
+            </IonToolbar>
+          </IonHeader>
+          <IonContent fullscreen>
             {
-              projectTasks.map(task => {
-                return (
-                  <TaskItem key={task._id} task={task} updateFn={getProject} />
-                  // <IonItem key={task._id} routerLink={"/tasks/" + task._id}>
-                  //   <IonCheckbox slot="start"></IonCheckbox>
-                  //   <IonLabel
-                  //     style={{textDecoration: (task.status == "Done" || task.status == "Cancelled") ? 'line-through' : 'none'}}
-                  //     color={(task.status == "Done" || task.status == "Cancelled") ? 'medium' : 'initial'}
-                  //   >
-                  //     {task.title}
-                  //   </IonLabel>
-                  // </IonItem>
-                )
-              })
-            }
-          </IonList>
-          : <p className="ion-padding" style={{color: 'var(--ion-color-medium)'}}>No tasks found! Add a task to <strong>"{project.title}"</strong> by clicking on the "+" button below.</p>
-        }
-
-        {
-          completedProjectTasks.length > 0
-          ? <IonList style={{marginTop: 24}}>
-            <IonListHeader>
-              <IonLabel>Completed</IonLabel>
-              <IonButton size="small" onClick={toggleCompletedTaskView}>{ showCompleted ? "Hide" : "Show" }</IonButton>
-            </IonListHeader>
-            {
-              showCompleted
-              ? completedProjectTasks.map(task => {
-                return (
-                  <TaskItem key={task._id} task={task} updateFn={getProject} />
-                )
-              })
+              project && project.status == "Archived" && project.status != "Completed"
+              ?  <div style={{display: 'flex', alignItems: 'center', justifyContent: 'center', gap: '4px', padding: '4px', textAlign: 'center', background: 'var(--ion-color-light-shade)', color: 'var(--ion-color-medium)', fontSize: '0.8rem', lineHeight: 1}}>
+                <IonIcon style={{fontSize: '0.79rem'}} icon={archiveSharp} color="medium"></IonIcon>
+                <IonLabel style={{lineHeight: 1.2}}>Archived</IonLabel>
+              </div>
               : null
             }
-          </IonList>
-          : null
-        }
- 
-        {
-          projectNotes.length > 0
-          ? <>
-          <IonList style={{marginTop: showCompleted ? 24 : 8}}>
-            <IonListHeader>Project Support Material</IonListHeader>
             {
-              projectNotes.map(note => {
-                return (
-                  <NoteItem key={note._id} note={note} />
-                )
-              })
+              project && project.status == "Completed"
+              ?  <div style={{display: 'flex', alignItems: 'center', justifyContent: 'center', gap: '4px', padding: '4px', textAlign: 'center', background: 'rgba(var(--ion-color-success-rgb), 0.7)', color: 'var(--ion-color-success-contrast)', fontSize: '0.8rem', lineHeight: 1}}>
+                <IonIcon style={{fontSize: '0.79rem'}} icon={checkmarkCircleSharp} color="light-shade"></IonIcon>
+                <IonLabel style={{lineHeight: 1.2}}>Completed</IonLabel>
+              </div>
+              : null
             }
-          </IonList>
-          </>
-          : null
-        }
+            <div style={{padding: '16px 16px 0'}}>
+              {/* <h3>{project.title}</h3> */}
+              <Title title={project.title} update={updateProjectTitle} />
+              {
+                !projectDescEditing
+                ? <div
+                  style={{color: project.description ? 'initial' : 'var(--ion-color-medium)'}}
+                  onClick={() => {
+                    setProjectDescEditing(true)
+                  }}
+                >
+                  <Markdown
+                  >
+                    {project.description ? project.description : 'Tap to set a description'}
+                  </Markdown>
+                </div>
+                : <div style={{display: 'flex', flexDirection: 'column', alignItems: 'flex-end', gap: 8}}>
+                  <IonTextarea ref={projectDescEditor} value={description} onIonInput={(e) => {setDescription(e.detail.value!)}} aria-label="Description" placeholder="Enter description" autoGrow={true} rows={1}></IonTextarea>
+                  <IonButton size="small" onClick={updateProjectDescription}>
+                    <IonIcon slot="icon-only" icon={checkmarkSharp}></IonIcon>
+                  </IonButton>
+                </div>
+              }
+            </div>
 
-        <div style={{marginTop: 32, padding: '16px'}}>
-          <small style={{display: 'block', marginBottom: 8, color: 'var(--ion-color-medium)'}}>
-            Created: {project.timestamps ? formatDistance(project.timestamps.created, Date.now()) + ' ago' : ''}
-          </small>
-          <small style={{display: 'block', marginBottom: 8, color: 'var(--ion-color-medium)'}}>
-            Updated: {project.timestamps ? formatDistance(project.timestamps.updated, Date.now()) + ' ago' : ''}
-          </small>
-          {
-            (project.timestamps && project.timestamps.completed)
-            ? <small style={{display: 'block', marginBottom: 8, color: 'var(--ion-color-medium)'}}>
-              Completed: {(project.timestamps && project.timestamps.completed) ? formatDistance(project.timestamps.completed, Date.now()) + ' ago' : ''}
-            </small>
-            : null
-          }
-          {
-            (project.timestamps && project.timestamps.archived)
-            ? <small style={{display: 'block', marginBottom: 8, color: 'var(--ion-color-medium)'}}>
-              Archived: {(project.timestamps && project.timestamps.archived) ? formatDistance(project.timestamps.archived, Date.now()) + ' ago' : ''}
-            </small>
-            : null
-          }
-        </div>
+            {
+              projectTasks.length > 0
+              ? <IonList style={{marginTop: 32}}>
+                {
+                  projectTasks.map(task => {
+                    return (
+                      <TaskItem key={task._id} task={task} updateFn={getProject} url={match.url} />
+                      // <IonItem key={task._id} routerLink={"/tasks/" + task._id}>
+                      //   <IonCheckbox slot="start"></IonCheckbox>
+                      //   <IonLabel
+                      //     style={{textDecoration: (task.status == "Done" || task.status == "Cancelled") ? 'line-through' : 'none'}}
+                      //     color={(task.status == "Done" || task.status == "Cancelled") ? 'medium' : 'initial'}
+                      //   >
+                      //     {task.title}
+                      //   </IonLabel>
+                      // </IonItem>
+                    )
+                  })
+                }
+              </IonList>
+              : <p className="ion-padding" style={{color: 'var(--ion-color-medium)'}}>No tasks found! Add a task to <strong>"{project.title}"</strong> by clicking on the "+" button below.</p>
+            }
 
-        <IonFab ref={fabRef} onClick={() => {fabRef.current?.activated ? setOverlayVisible(true) : setOverlayVisible(false)}} slot='fixed' vertical='bottom' horizontal='end'>
-          <IonFabButton>
-            <IonIcon icon={add}></IonIcon>
-          </IonFabButton>
-          <IonFabList side="top">
-            <IonFabButton routerLink={"/project/add-task/" + match.params.id} data-title="Add task">
-              <IonIcon icon={checkmarkSharp}></IonIcon>
-            </IonFabButton>
-            <IonFabButton routerLink={"/notes/add/" + match.params.id} data-title="Add note">
-              <IonIcon icon={documentTextSharp}></IonIcon>
-            </IonFabButton>
-          </IonFabList>
-        </IonFab>
+            {
+              completedProjectTasks.length > 0
+              ? <IonList style={{marginTop: 24}}>
+                <IonListHeader>
+                  <IonLabel>Completed</IonLabel>
+                  <IonButton size="small" onClick={toggleCompletedTaskView}>{ showCompleted ? "Hide" : "Show" }</IonButton>
+                </IonListHeader>
+                {
+                  showCompleted
+                  ? completedProjectTasks.map(task => {
+                    return (
+                      <TaskItem key={task._id} task={task} updateFn={getProject} />
+                    )
+                  })
+                  : null
+                }
+              </IonList>
+              : null
+            }
+    
+            {
+              projectNotes.length > 0
+              ? <>
+              <IonList style={{marginTop: showCompleted ? 24 : 8}}>
+                <IonListHeader>Project Support Material</IonListHeader>
+                {
+                  projectNotes.map(note => {
+                    return (
+                      <NoteItem key={note._id} note={note} />
+                    )
+                  })
+                }
+              </IonList>
+              </>
+              : null
+            }
 
-        <IonActionSheet
-          trigger='openProjectActionsSheet'
-          header='Project actions'
-          buttons={[
-            {
-              text: project.status != "Archived" ? 'Archive' : 'Unarchive',
-              icon: archiveSharp,
-              data: {
-                action: 'archive-project'
+            <div style={{marginTop: 32, padding: '16px'}}>
+              <small style={{display: 'block', marginBottom: 8, color: 'var(--ion-color-medium)'}}>
+                Created: {project.timestamps ? formatDistance(project.timestamps.created, Date.now()) + ' ago' : ''}
+              </small>
+              <small style={{display: 'block', marginBottom: 8, color: 'var(--ion-color-medium)'}}>
+                Updated: {project.timestamps ? formatDistance(project.timestamps.updated, Date.now()) + ' ago' : ''}
+              </small>
+              {
+                (project.timestamps && project.timestamps.completed)
+                ? <small style={{display: 'block', marginBottom: 8, color: 'var(--ion-color-medium)'}}>
+                  Completed: {(project.timestamps && project.timestamps.completed) ? formatDistance(project.timestamps.completed, Date.now()) + ' ago' : ''}
+                </small>
+                : null
               }
-            },
-            {
-              text: project.status != "Completed" ? 'Mark complete' : 'Mark in progress',
-              icon: archiveSharp,
-              data: {
-                action: 'complete-project'
+              {
+                (project.timestamps && project.timestamps.archived)
+                ? <small style={{display: 'block', marginBottom: 8, color: 'var(--ion-color-medium)'}}>
+                  Archived: {(project.timestamps && project.timestamps.archived) ? formatDistance(project.timestamps.archived, Date.now()) + ' ago' : ''}
+                </small>
+                : null
               }
-            },
-            {
-              text: 'Delete',
-              icon: trashSharp,
-              role: 'destructive',
-              data: {
-                action: 'delete-project'
-              }
-            },
-            {
-              text: 'Cancel',
-              icon: closeSharp,
-              role: 'cancel',
-              data: {
-              }
-            }
-          ]}
-          onDidDismiss={({detail}) => {
-            if(detail.data?.action == 'delete-project') {
-              deleteProjectConfirmation.current?.present()
-            } else if(detail.data?.action == 'archive-project') {
-              archiveProject()
-            } else if(detail.data?.action == 'complete-project') {
-              completeProject()
-            }
-          }}
-        ></IonActionSheet>
-        <IonAlert
-          ref={deleteProjectConfirmation}
-          // trigger="task-delete-confirmation"
-          header="Delete Project?"
-          message="This will permanently remove the Project, and all Tasks, and Notes associated with this Project. Do you wish to continue?"
-          buttons={[
-            {
-              text: 'Cancel',
-              role: 'cancel',
-            },
-            {
-              text: 'Delete',
-              role: 'destructive'
-            }
-          ]}
-          onDidDismiss={({detail}) => {
-            if(detail.role == 'destructive') {
-              deleteProject()
-            }
-          }}
-        ></IonAlert>
-      </IonContent>
-    </IonPage>
+            </div>
+
+            <IonFab ref={fabRef} onClick={() => {fabRef.current?.activated ? setOverlayVisible(true) : setOverlayVisible(false)}} slot='fixed' vertical='bottom' horizontal='end'>
+              <IonFabButton>
+                <IonIcon icon={add}></IonIcon>
+              </IonFabButton>
+              <IonFabList side="top">
+                <IonFabButton routerLink={"/project/add-task/" + match.params.id} data-title="Add task">
+                  <IonIcon icon={checkmarkSharp}></IonIcon>
+                </IonFabButton>
+                <IonFabButton routerLink={"/notes/add/" + match.params.id} data-title="Add note">
+                  <IonIcon icon={documentTextSharp}></IonIcon>
+                </IonFabButton>
+              </IonFabList>
+            </IonFab>
+
+            <IonActionSheet
+              trigger='openProjectActionsSheet'
+              header='Project actions'
+              buttons={[
+                {
+                  text: project.status != "Archived" ? 'Archive' : 'Unarchive',
+                  icon: archiveSharp,
+                  data: {
+                    action: 'archive-project'
+                  }
+                },
+                {
+                  text: project.status != "Completed" ? 'Mark complete' : 'Mark in progress',
+                  icon: archiveSharp,
+                  data: {
+                    action: 'complete-project'
+                  }
+                },
+                {
+                  text: 'Delete',
+                  icon: trashSharp,
+                  role: 'destructive',
+                  data: {
+                    action: 'delete-project'
+                  }
+                },
+                {
+                  text: 'Cancel',
+                  icon: closeSharp,
+                  role: 'cancel',
+                  data: {
+                  }
+                }
+              ]}
+              onDidDismiss={({detail}) => {
+                if(detail.data?.action == 'delete-project') {
+                  deleteProjectConfirmation.current?.present()
+                } else if(detail.data?.action == 'archive-project') {
+                  archiveProject()
+                } else if(detail.data?.action == 'complete-project') {
+                  completeProject()
+                }
+              }}
+            ></IonActionSheet>
+            <IonAlert
+              ref={deleteProjectConfirmation}
+              // trigger="task-delete-confirmation"
+              header="Delete Project?"
+              message="This will permanently remove the Project, and all Tasks, and Notes associated with this Project. Do you wish to continue?"
+              buttons={[
+                {
+                  text: 'Cancel',
+                  role: 'cancel',
+                },
+                {
+                  text: 'Delete',
+                  role: 'destructive'
+                }
+              ]}
+              onDidDismiss={({detail}) => {
+                if(detail.role == 'destructive') {
+                  deleteProject()
+                }
+              }}
+            ></IonAlert>
+          </IonContent>
+        </IonPage>
+      </div>
+      <IonRouterOutlet style={{width: router.routeInfo.pathname.includes("tasks") ? '34vw' : 0, marginLeft: '33vw'}}>
+        <Route path="/project/details/:projectid/tasks/:id" component={TaskDetails}/>
+      </IonRouterOutlet>
+    </>
   )
 }
 

--- a/src/pages/Projects.tsx
+++ b/src/pages/Projects.tsx
@@ -1,10 +1,13 @@
-import { IonBackButton, IonButton, IonButtons, IonCol, IonContent, IonFab, IonFabButton, IonGrid, IonHeader, IonIcon, IonItem, IonLabel, IonList, IonPage, IonRow, IonSpinner, IonText, IonTitle, IonToolbar, isPlatform, useIonViewDidEnter } from "@ionic/react"
+import { IonBackButton, IonButton, IonButtons, IonCol, IonContent, IonFab, IonFabButton, IonGrid, IonHeader, IonIcon, IonItem, IonLabel, IonList, IonPage, IonRouterOutlet, IonRow, IonSpinner, IonText, IonTitle, IonToolbar, isPlatform, useIonViewDidEnter } from "@ionic/react"
 import { add, ellipsisVerticalCircleOutline, ellipsisVerticalOutline, ellipsisVerticalSharp } from "ionicons/icons"
 import './Projects.css'
 import PouchDB from "pouchdb"
 import PouchFind from "pouchdb-find"
 import CordovaSqlite from "pouchdb-adapter-cordova-sqlite"
 import { useState } from "react"
+import { Redirect, Route, RouteComponentProps } from "react-router"
+import ProjectDetailsPage from "./ProjectDetails"
+import TaskDetails from "./TaskDetails"
 
 const ProjectsPage: React.FC = () => {
 
@@ -94,52 +97,66 @@ const ProjectsPage: React.FC = () => {
   }
 
   return (
-    <IonPage>
-      <IonHeader className="ion-no-border">
-        <IonToolbar>
-          <IonButtons slot='start'>
-            <IonBackButton defaultHref="/"></IonBackButton>
-          </IonButtons>
-          <IonTitle>Projects</IonTitle>
-          <IonButtons slot='end'>
-            <IonButton id="openFilterBottomSheet">
-              <IonIcon slot="icon-only" icon={ellipsisVerticalSharp}></IonIcon>
-            </IonButton>
-          </IonButtons>
-        </IonToolbar>
-      </IonHeader>
-      <IonContent fullscreen>
-        <IonList>
-          {
-            projects.length > 0
-            ? projects.map((project, index) => {
-              return (
-                <IonItem key={project._id} routerLink={"/project/details/" + project._id} lines={index == projects.length - 1 ? "none" : "inset"}>
-                  <div
-                    style={
-                      {
-                        '--duet-project-progress': (project.tasks ? ( projectsProgress.find(p => p.key == project._id).value.complete / projectsProgress.find(p => p.key == project._id).value.total * 100 ) : 0)
-                      }
-                    }
-                    className="project-progress"
-                  ></div>
-                  <IonLabel>{project.title}</IonLabel>
-                </IonItem>
-              )
-            })
-            : <div className="ion-padding">
-              <IonText color="medium">No projects found! Create a new project by pressing the + button below.</IonText>
-            </div>
-          }
-        </IonList>
+    <>
+      <div style={{width: '33vw'}}>
+        <IonPage style={{width: '33vw', borderRight: window.innerWidth > 992 ? '1px solid rgba(var(--ion-color-medium-rgb), 0.1)' : 'none'}}>
+          <IonHeader className="ion-no-border">
+            <IonToolbar>
+              <IonButtons slot='start'>
+                <IonBackButton defaultHref="/"></IonBackButton>
+              </IonButtons>
+              <IonTitle>Projects</IonTitle>
+              <IonButtons slot='end'>
+                <IonButton id="openFilterBottomSheet">
+                  <IonIcon slot="icon-only" icon={ellipsisVerticalSharp}></IonIcon>
+                </IonButton>
+              </IonButtons>
+            </IonToolbar>
+          </IonHeader>
+          <IonContent fullscreen>
+            <IonList>
+              {
+                projects.length > 0
+                ? projects.map((project, index) => {
+                  return (
+                    <IonItem key={project._id} routerLink={"/project/details/" + project._id} lines={index == projects.length - 1 ? "none" : "inset"}>
+                      <div
+                        style={
+                          {
+                            '--duet-project-progress': (project.tasks ? ( projectsProgress.find(p => p.key == project._id).value.complete / projectsProgress.find(p => p.key == project._id).value.total * 100 ) : 0)
+                          }
+                        }
+                        className="project-progress"
+                      ></div>
+                      <IonLabel>{project.title}</IonLabel>
+                    </IonItem>
+                  )
+                })
+                : <div className="ion-padding">
+                  <IonText color="medium">No projects found! Create a new project by pressing the + button below.</IonText>
+                </div>
+              }
+            </IonList>
 
-        <IonFab slot='fixed' vertical='bottom' horizontal='end'>
-          <IonFabButton routerLink="/project/add">
-            <IonIcon icon={add}></IonIcon>
-          </IonFabButton>
-        </IonFab>
-      </IonContent>
-    </IonPage>
+            <IonFab slot='fixed' vertical='bottom' horizontal='end'>
+              <IonFabButton routerLink="/project/add">
+                <IonIcon icon={add}></IonIcon>
+              </IonFabButton>
+            </IonFab>
+          </IonContent>
+        </IonPage>
+      </div>
+      <IonRouterOutlet style={{width: '67vw', marginLeft: '33vw'}}>
+        <Route exact={true} path="/project">
+          <Redirect to="/project/_" />
+        </Route>
+        <Route exact path="/project/_">
+          <IonText>Pick a project</IonText>
+        </Route>
+        <Route path="/project/details/:id" component={ProjectDetailsPage} />
+        {/* <Route path={"/project/tasks/:id"} component={TaskDetails}/> */}
+      </IonRouterOutlet>
+    </>
   ) 
 }
 

--- a/src/pages/TaskDetails.tsx
+++ b/src/pages/TaskDetails.tsx
@@ -13,10 +13,14 @@ import Description from '../components/Title/Description'
 import { formatDistance } from 'date-fns'
 
 interface TaskDetailsPageProps extends RouteComponentProps<{
+  projectid?: string,
   id: string
 }> {}
 
 const TaskDetails: React.FC<TaskDetailsPageProps> = ({match}) => {
+
+  // console.log("ProjectID", match.params.projectid!)
+  console.log("TaskID", match.params.id)
 
   let db: PouchDB.Database
   if(isPlatform('capacitor')) {

--- a/src/pages/Today.tsx
+++ b/src/pages/Today.tsx
@@ -5,11 +5,11 @@ import PouchDB from "pouchdb"
 import PouchFind from "pouchdb-find"
 import CordovaSqlite from "pouchdb-adapter-cordova-sqlite"
 import { endOfToday, formatISO, startOfToday } from "date-fns";
-import { useHistory } from "react-router";
+import { RouteComponentProps, useHistory } from "react-router";
 import TaskItem from "../components/Tasks/TaskItem";
 import TasksSkeletonLoader from "../components/TasksSkeletonLoader";
 
-const Today: React.FC = () => {
+const Today: React.FC<RouteComponentProps> = ({match}) => {
 
   let db: PouchDB.Database
   if(isPlatform('capacitor')) {
@@ -272,7 +272,7 @@ const Today: React.FC = () => {
             {
               filteredOverdueTasks.map(task => {
                 return (
-                  <TaskItem key={task._id} task={task} updateFn={getTodaysTasks} project={task.project_id ? projects.find(p => p._id == task.project_id) : null} />
+                  <TaskItem key={task._id} task={task} updateFn={getTodaysTasks} project={task.project_id ? projects.find(p => p._id == task.project_id) : null} url={match?.url} />
                 )
               })
             }
@@ -288,7 +288,7 @@ const Today: React.FC = () => {
             {
               filteredTodaysTasks.map(task => {
                 return (
-                  <TaskItem key={task._id} task={task} updateFn={getTodaysTasks} project={task.project_id ? projects.find(p => p._id == task.project_id) : null} />
+                  <TaskItem key={task._id} task={task} updateFn={getTodaysTasks} project={task.project_id ? projects.find(p => p._id == task.project_id) : null} url={match?.url} />
                 )
               })
             }

--- a/src/pages/Upcoming.tsx
+++ b/src/pages/Upcoming.tsx
@@ -6,8 +6,9 @@ import PouchFind from "pouchdb-find"
 import CordovaSqlite from "pouchdb-adapter-cordova-sqlite"
 import { endOfToday, formatISO, startOfToday } from "date-fns";
 import TaskItem from "../components/Tasks/TaskItem";
+import { RouteComponentProps } from "react-router";
 
-const Upcoming: React.FC = () => {
+const Upcoming: React.FC<RouteComponentProps> = ({match}) => {
 
   let db: PouchDB.Database
   if(isPlatform('capacitor')) {
@@ -72,7 +73,7 @@ const Upcoming: React.FC = () => {
             {
               upcomingTasks.map(task => {
                 return (
-                  <TaskItem key={task._id} task={task} updateFn={getUpcomingTasks} />
+                  <TaskItem key={task._id} task={task} updateFn={getUpcomingTasks} url={match?.url} />
                   // <IonItem key={task._id} routerLink={"/tasks/" + task._id}>
                   //   <IonCheckbox legacy={true} slot="start"></IonCheckbox>
                   //   <IonLabel style={{textDecoration: task.status == "Done" ? 'line-through' : 'none'}} color={task.status == "Done" ? 'medium' : 'initial'}>{task.title}</IonLabel>

--- a/src/pages/Waiting.tsx
+++ b/src/pages/Waiting.tsx
@@ -8,8 +8,9 @@ import '../taskList.css'
 import { OverlayEventDetail } from "@ionic/react/dist/types/components/react-component-lib/interfaces";
 import TaskItem from "../components/Tasks/TaskItem";
 import TasksSkeletonLoader from "../components/TasksSkeletonLoader";
+import { RouteComponentProps } from "react-router";
 
-const Waiting: React.FC = () => {
+const Waiting: React.FC<RouteComponentProps> = ({match}) => {
 
   let db: PouchDB.Database
   if(isPlatform('capacitor')) {
@@ -74,7 +75,7 @@ const Waiting: React.FC = () => {
             {
               waitingTasks.map(task => {
                 return (
-                  <TaskItem key={task._id} task={task} updateFn={getWaitingTasks} />
+                  <TaskItem key={task._id} task={task} updateFn={getWaitingTasks} url={match?.url} />
                 )
               })
             }

--- a/src/taskList.css
+++ b/src/taskList.css
@@ -16,3 +16,7 @@ ion-item.task-item .status-wrapper ion-icon {
 ion-item.task-item button {
   z-index: 3;
 }
+
+ion-item.task-item.active {
+  background: var(--ion-background-color-step-50);
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -29,5 +29,6 @@ interface Project extends PouchDB.Core.ExistingDocument<{
 type TaskItemProps = {
   task: Task,
   updateFn: () => void,
-  project?: Project
+  project?: Project,
+  url?: string
 }


### PR DESCRIPTION
Adding experimental multi-pane support for the UI when on bigger screen devices such as desktops or tablets.

Summary of changes in this commit:

- Reactive hook to determine screen size
- New component to load a placeholder multi-pane UI on initial app open
- Hybrid two-pane and three-pane layout on big screens as per context
- Cleaned up existing routes for semantic readability of path names
- Updated types for route components to allow usage of single URL across different sized devices
- Added visual cues to show parent-child hierarchy in multi-pane UI