### PR TITLE
fix(core): Don't set note title as empty on blur

### DIFF
--- a/src/pages/NoteDetails.tsx
+++ b/src/pages/NoteDetails.tsx
@@ -96,6 +96,9 @@ const NoteDetails: React.FC<NoteDetailsPageProps> = ({match}) => {
 
 
   const updateNoteTitle = async (title: string) => {
+    if(note.title === title) {
+      return
+    }
     setNote({...note, title: title})
     const timestamp = new Date().toISOString()
     


### PR DESCRIPTION
When accidentally defocusing from the title of the note whilst editing a note, ensure that the note title isn't updated to an empty string (since no change has taken place).