### PR TITLE
fix(core): Fix project details screen that contained deleted tasks

### DIFF
--- a/src/pages/ProjectDetails.tsx
+++ b/src/pages/ProjectDetails.tsx
@@ -69,8 +69,10 @@ const ProjectDetailsPage: React.FC<ProjectDetailsPageProps> = ({match}) => {
       let tasks = []
       let completedTasks = []
       result.rows.forEach(row => {
-        tasks.push(row.doc)
-        completedTasks.push(row.doc)
+        if(row.doc) {
+          tasks.push(row.doc)
+          completedTasks.push(row.doc)
+        } 
       });
       tasks = tasks.filter(t => (t.status != "Done")).filter(t => t.status != "Cancelled")
       completedTasks = completedTasks.filter(t => (t.status == "Done"))


### PR DESCRIPTION
The Project Details screen would break when tasks were deleted from the project. This was being fetched by PouchDB, and the function that filtered tasks couldn't find the doc object. Added a check for this and fixed the issue.