### PR TITLE
fix(ux): Fix redirection to Add task screen upon adding new project

### DIFF
--- a/src/pages/AddProject.tsx
+++ b/src/pages/AddProject.tsx
@@ -66,7 +66,7 @@ const AddProject: React.FC = () => {
         {
           title.length > 0 &&
           <IonFab slot='fixed' vertical='bottom' horizontal='end'>
-            <IonFabButton onClick={addProject} routerLink="/add-task">
+            <IonFabButton onClick={addProject}>
               <IonIcon icon={checkmark}></IonIcon>
             </IonFabButton>
           </IonFab>


### PR DESCRIPTION
When adding a project, the app would redirect the user to the add task screen. Adding a fix for this by removing router-link attribute.