### PR TITLE
feat(ux): Improve flow of Today screen workflow

### DIFF
--- a/src/components/Tasks/TaskItem.tsx
+++ b/src/components/Tasks/TaskItem.tsx
@@ -1,10 +1,11 @@
 import { IonIcon, IonItem, IonLabel, IonRippleEffect, isPlatform, useIonModal, useIonRouter } from "@ionic/react";
-import { checkmarkCircle, chevronForwardCircleOutline, ellipseOutline, pauseCircleOutline, removeCircle } from "ionicons/icons";
+import { calendarNumberOutline, checkmarkCircle, chevronForwardCircleOutline, ellipseOutline, folder, folderOutline, pauseCircleOutline, removeCircle } from "ionicons/icons";
 import StatusPickerModal from "./StatusPickerModal";
 import { OverlayEventDetail } from "@ionic/react/dist/types/components/react-component-lib/interfaces";
 import PouchDB from "pouchdb"
 import PouchFind from "pouchdb-find"
 import CordovaSqlite from "pouchdb-adapter-cordova-sqlite"
+import { formatRelative, subDays } from "date-fns";
 
 const TaskItem: React.FC<TaskItemProps> = (props) => {
 
@@ -91,11 +92,30 @@ const TaskItem: React.FC<TaskItemProps> = (props) => {
         color={task.status == "Done" ? 'medium' : 'initial'}
       >
         {task.title}
-        {
-          project
-          ? <p>{project.title}</p>
-          : null
-        }
+        <p>
+          {
+            project
+            ? <span style={{display: 'inline-flex', alignItems: 'center', gap: 8}}><IonIcon icon={folderOutline}></IonIcon> {project.title}, </span>
+            : null 
+          }
+          {
+            task.due_date
+            ? <span style={{display: 'inline-flex', alignItems: 'center', gap: 8}}>
+                <IonIcon icon={calendarNumberOutline}></IonIcon> 
+                {formatRelative(task.due_date, new Date())}
+              </span> 
+            : null
+          }
+          {
+            task.scheduled_date && task.due_date == null
+            ? <span style={{display: 'inline-flex', alignItems: 'center', gap: 8}}>
+                <IonIcon icon={calendarNumberOutline}></IonIcon> 
+                {formatRelative(task.scheduled_date, new Date())}
+              </span> 
+            : null
+          }
+        </p>
+        
       </IonLabel>
     </IonItem>
   )

--- a/src/pages/TaskDetails.tsx
+++ b/src/pages/TaskDetails.tsx
@@ -10,7 +10,7 @@ import { archiveOutline, arrowBackSharp, arrowForwardSharp, checkmark, checkmark
 import Markdown from 'react-markdown'
 import Title from '../components/Title/Title'
 import Description from '../components/Title/Description'
-import { formatDistance } from 'date-fns'
+import { format, formatDistance, formatRelative } from 'date-fns'
 
 interface TaskDetailsPageProps extends RouteComponentProps<{
   projectid?: string,
@@ -465,13 +465,13 @@ const TaskDetails: React.FC<TaskDetailsPageProps> = ({match}) => {
           <IonItem lines='inset' id='openschedulemodal'>
             <IonLabel>
               <p>Scheduled to start on</p>
-              <div>{(scheduledDate) ? new Date(scheduledDate).toLocaleDateString() : 'Set start date'}</div>
+              <div>{(scheduledDate) ? formatRelative(scheduledDate, new Date()) : 'Set start date'}</div>
             </IonLabel>
           </IonItem>
           <IonItem lines='inset' id='openduemodal'>
             <IonLabel>
-              <p>Due on</p>
-              <div>{(dueDate) ? new Date(dueDate).toLocaleDateString() : 'Set due date'}</div>
+              <p>Due</p>
+              <div>{(dueDate) ? formatRelative(dueDate, new Date()) : 'Set due date'}</div>
             </IonLabel>
           </IonItem>
           {
@@ -551,12 +551,12 @@ const TaskDetails: React.FC<TaskDetailsPageProps> = ({match}) => {
         ></IonActionSheet>
 
         <IonModal keepContentsMounted={true} trigger='openschedulemodal' className='datePickerModal'>
-          <IonDatetime value={scheduledDate} onIonChange={(e: IonDatetimeCustomEvent<DatetimeChangeEventDetail>) => {updateTaskScheduledDate(e)}} showDefaultTitle={true} showDefaultButtons={true} showClearButton={true} presentation="date" id="scheduleddatetime">
+          <IonDatetime value={scheduledDate} onIonChange={(e: IonDatetimeCustomEvent<DatetimeChangeEventDetail>) => {updateTaskScheduledDate(e)}} showDefaultTitle={true} showDefaultButtons={true} showClearButton={true} presentation="date-time" minuteValues={[0, 5, 10, 15, 20, 25, 30, 35, 40, 45, 50, 55]} id="scheduleddatetime">
             <span slot="title">Select start date</span>
           </IonDatetime>
         </IonModal>
         <IonModal keepContentsMounted={true} trigger='openduemodal' className='datePickerModal'>
-          <IonDatetime value={scheduledDate} onIonChange={(e: IonDatetimeCustomEvent<DatetimeChangeEventDetail>) => {updateTaskDueDate(e)}} showDefaultTitle={true} showDefaultButtons={true} showClearButton={true} presentation="date" id="scheduleddatetime">
+          <IonDatetime value={dueDate} onIonChange={(e: IonDatetimeCustomEvent<DatetimeChangeEventDetail>) => {updateTaskDueDate(e)}} showDefaultTitle={true} showDefaultButtons={true} showClearButton={true} presentation="date-time" minuteValues={[0, 5, 10, 15, 20, 25, 30, 35, 40, 45, 50, 55]} id="scheduleddatetime">
             <span slot="title">Select due date</span>
           </IonDatetime>
         </IonModal>

--- a/src/taskList.css
+++ b/src/taskList.css
@@ -7,6 +7,8 @@ ion-item.task-item .status-wrapper {
   position: relative;
   overflow: hidden;
   border-radius: 50%;
+  align-self: flex-start;
+  margin-top: 6px;
 }
 
 ion-item.task-item .status-wrapper ion-icon {


### PR DESCRIPTION
## [feat(ux): More nuanced use of due & scheduled date](https://github.com/Duet-App/duet-app/commit/6ea280c2e1f3840cad78f2f88dd8d573f471c00a)

Make more nuanced use of the due and scheduled dates. Added support on the Today screen to order tasks and overdue tasks by the due date field instead of using the scheduled date field. Add list separation headers for better UX, and also show tasks that have been started in the past, but have no due date set in a separate list on the Today screen.

## [feat(ux): Improve task list item with more info](https://github.com/Duet-App/duet-app/commit/80dd1a383cddca30cad6eea5e078b5d7d31d45bd)

Show the scheduled and due dates, and also add icons for these as well
as the project for easier scanning of lists.

Moved the status icon to be in line with first line of task's title.

Also added a new [feat(ui): Pick time in due & start dates for tasks](https://github.com/Duet-App/duet-app/commit/74d79ade89fb46971d3a9e63f50c43301d92a45e)