### PR TITLE
fix(ux): Better performance in the app

### DIFF
--- a/src/components/Home/List/Notes.tsx
+++ b/src/components/Home/List/Notes.tsx
@@ -20,25 +20,30 @@ const NotesTile: React.FC = () => {
   const [notes, setNotes] = useState([])
 
   useIonViewDidEnter(() => {
-    function getNotes() {
-      db.find({
-        selector: {
-          "timestamps.updated": {
-            "$gt": null
+    async function getNotes() {
+      try {
+        await db.createIndex({
+          index: {
+            fields: ['timestamps.updated'],
+          }
+        })
+        const result: object | null = await db.find({
+          selector: {
+            "timestamps.updated": {
+              "$gt": null
+            },
+            type: "note",
           },
-          type: "note",
-        },
-        // "use_index": ['inbox-items', 'inbox-items'],
-        sort: [{'timestamps.updated': 'desc'}],
-        limit: 3
-      })
-      .then((result: object | null) => {
+          // "use_index": ['inbox-items', 'inbox-items'],
+          sort: [{'timestamps.updated': 'desc'}],
+          limit: 3
+        })
         if(result) {
           setNotes(result.docs)
         }
-      }).catch((err: Error) => {
-        console.log(err)
-      })
+      } catch (err) {
+        throw err
+      }
     }
 
     getNotes()

--- a/src/dbHelper.ts
+++ b/src/dbHelper.ts
@@ -1,0 +1,92 @@
+export const projects_progress_ddoc = {
+  "_id": "_design/projects-progress-ddoc",
+  views: {
+    "project-progress": {
+      map: function mapFun(doc) {
+        if(doc.type == "task" && doc.project_id) {
+          emit(doc.project_id, {type: "task", status: doc.status});
+        }
+      }.toString(),
+      reduce: function redFun(keys, values, rereduce) {
+        if (rereduce) {
+          return values;
+        } else {
+          var total = 0;
+          var complete = 0;
+          for(var i = 0; i < values.length; i++) {
+            if(values[i].type == "task") {
+              if(values[i].status == "Done" || values[i].status == "Cancelled") {
+                complete = complete + 1;
+              }
+              total = total + 1;
+            }
+          }
+          return {total: total, complete: complete};
+        }
+      }.toString()
+    }
+  }
+}
+
+export const projects_ddoc = {
+  "_id": "_design/projects-ddoc",
+  views: {
+    "project-tasks": {
+      map: function mapFun(doc) {
+        if(doc.type == "project" && doc.tasks) {
+          for(var i in doc.tasks) {
+            emit([doc._id, Number(i)+1], {_id: doc.tasks[i]})
+          }
+        }
+      }.toString()
+    },
+    "project-notes": {
+      map: function mapFun(doc) {
+        if(doc.type == "project" && doc.notes) {
+          for(var i in doc.notes) {
+            emit([doc._id, Number(i)+1], {_id: doc.notes[i]})
+          }
+        }
+      }.toString()
+    },
+    "project-progress": {
+      map: function mapFun(doc) {
+        if(doc.type == "task" && doc.project_id) {
+          emit(doc.project_id, {type: "task", status: doc.status});
+        }
+      }.toString(),
+      reduce: function redFun(keys, values, rereduce) {
+        if (rereduce) {
+          return values;
+        } else {
+          var total = 0;
+          var complete = 0;
+          for(var i = 0; i < values.length; i++) {
+            if(values[i].type == "task") {
+              if(values[i].status == "Done" || values[i].status == "Cancelled") {
+                complete = complete + 1;
+              }
+              total = total + 1;
+            }
+          }
+          return {total: total, complete: complete};
+        }
+      }.toString()
+    }
+  }
+}
+
+export const projects_notes_ddoc = {
+  "_id": "_design/projects-notes-ddoc",
+  views: {
+    "project-notes": {
+      map: function mapFun(doc) {
+        if(doc.type == "project" && doc.notes) {
+          for(var i in doc.notes) {
+            emit([doc._id, Number(i)+1], {_id: doc.notes[i]})
+          }
+        }
+      }.toString()
+    },
+  }
+}

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -55,6 +55,43 @@ const Home: React.FC = () => {
 
   let db: PouchDB.Database
 
+  const setupIndexes = async () => {
+    await db.createIndex({
+      index: {
+        fields: ['timestamps.created']
+      }
+    })
+    await db.createIndex({
+      index: {
+        fields: ['scheduled_date']
+      }
+    })
+    await db.createIndex({
+      index: {
+        fields: ['status', 'type', 'project_id']
+      }
+    })
+    await db.createIndex({
+      index: {
+        fields: ['status', 'type', 'scheduled_date']
+      }
+    })
+    await db.createIndex({
+      index: {
+        fields: ['type']
+      }
+    })
+    await db.createIndex({
+      index: {
+        fields: ['timestamps.updated'],
+      }
+    })
+    await setupTagsDDoc()
+    // await setupProjectsDDoc()
+    // await setupProjectsProgressDDoc()
+    // await setupProjectsNotesDDoc()
+  }
+
   if(isPlatform('capacitor')) {
     document.addEventListener('deviceready', async function () {
       PouchDB.plugin(CordovaSqlite)
@@ -87,50 +124,13 @@ const Home: React.FC = () => {
           })
         })
       }
+
+      setupIndexes()
     })
   } else {
     db = new PouchDB('duet')
   }
   PouchDB.plugin(PouchFind)
-
-  const setupIndexes = async () => {
-    await db.createIndex({
-      index: {
-        fields: ['timestamps.created']
-      }
-    })
-    await db.createIndex({
-      index: {
-        fields: ['scheduled_date']
-      }
-    })
-    await db.createIndex({
-      index: {
-        fields: ['status', 'type', 'project_id']
-      }
-    })
-    await db.createIndex({
-      index: {
-        fields: ['status', 'type', 'scheduled_date']
-      }
-    })
-    await db.createIndex({
-      index: {
-        fields: ['type']
-      }
-    })
-    await db.createIndex({
-      index: {
-        fields: ['timestamps.updated'],
-        type: 'json'
-      }
-    })
-    await setupTagsDDoc()
-    await setupProjectsDDoc()
-    await setupProjectsProgressDDoc()
-    await setupProjectsNotesDDoc()
-  }
-
   setupIndexes()
 
   const tags_ddoc = {
@@ -256,15 +256,16 @@ const Home: React.FC = () => {
   }
 
   const setupProjectsDDoc = async () => {
-    let current_projects_ddoc_rev
-    db.get("_design/projects-ddoc").then((response) => {
-      current_projects_ddoc_rev = response._rev
-    })
+    // let current_projects_ddoc_rev
+    // db.get("_design/projects-ddoc").then((response) => {
+    //   current_projects_ddoc_rev = response._rev
+    // })
     try {
-      await db.put({
-        ...projects_ddoc,
-        _rev: current_projects_ddoc_rev
-      });
+      // await db.put({
+      //   ...projects_ddoc,
+      //   _rev: current_projects_ddoc_rev
+      // });
+      await db.put(projects_ddoc)
     } catch (err) {
       if (err.name !== 'conflict') {
         throw err;

--- a/src/pages/ProjectDetails.tsx
+++ b/src/pages/ProjectDetails.tsx
@@ -13,6 +13,7 @@ import Title from "../components/Title/Title"
 import "./fab.css"
 import TaskDetails from "./TaskDetails"
 import useScreenSize from "../hooks/useScreenSize"
+import { projects_ddoc, projects_notes_ddoc } from "../dbHelper"
 
 interface ProjectDetailsPageProps extends RouteComponentProps<{
   id: string
@@ -55,11 +56,18 @@ const ProjectDetailsPage: React.FC<ProjectDetailsPageProps> = ({match}) => {
     const doc = await db.get(match.params.id, {latest: true})
     setProject(doc)
     setDescription(doc.description)
-    getProjectTasks()
-    getProjectNotes()
+    await getProjectTasks()
+    await getProjectNotes()
   }
 
   async function getProjectTasks() {
+    try {
+      await db.put(projects_ddoc)
+    } catch (err) {
+      if(err.name !== 'conflict') {
+        throw err
+      }
+    }
     const result = await db.query('projects-ddoc/project-tasks', {
       startkey: [match.params.id],
       endkey: [match.params.id, {}],
@@ -82,6 +90,13 @@ const ProjectDetailsPage: React.FC<ProjectDetailsPageProps> = ({match}) => {
   }
 
   async function getProjectNotes() {
+    try {
+      await db.put(projects_notes_ddoc)
+    } catch (err) {
+      if(err.name !== 'conflict') {
+        throw err
+      }
+    }
     const result = await db.query('projects-notes-ddoc/project-notes', {
       startkey: [match.params.id],
       endkey: [match.params.id, {}],


### PR DESCRIPTION
A set of commits that focus on making the app slightly more performant when executing queries. Also fixing a few annoying DB related bugs on the Android app.

---

- [fix(core): Move index creation after deviceready](https://github.com/Duet-App/duet-app/commit/cd8b772fef0615a6f1975820ee3ebfd7907deeac)\
  
  On Capacitor, ensure that the index creation happens only after the
deviceready event from Cordova has fired so that we know that the DB is
ready for use. On non-Capacitor platforms, just fire it as soon as the
PouchDB plugin is setup.
  
  This should fix the issue of the Android app not loading data upon cold
launch at times.
  
- [refactor: Move ddoc definitions to new dbHelper](https://github.com/Duet-App/duet-app/commit/66180569d2b9faff42773dc076747d0fa7d2e745)\
  
  Preparing for future by moving code to a helper function for more easier
maintenance of DB related stuff.
  
- [fix(core): Call ddoc, index creation when required](https://github.com/Duet-App/duet-app/commit/b6e3e41c693f9944c83cacc705e658debb36a470)\
  
  In the Projects component, call the ddoc for project related stuff only
when required instead of calling it at app launch; this will ensure
better performance without impacting user experience without need.
  
  Also fetch the project progress before fetching the list of projects.
  
  This fixes an issue where adding a task to an empty and new project,
and then returning to the projects screen would crash the app because
the project would not be fetched yet.
  
- [refactor: Move PDB calls to Promise Async](https://github.com/Duet-App/duet-app/commit/314f45dfe164cf65721328aca7149d5a3c1298ef)\
  
  Move the Notes component calls to use the Promise Async approach and
also call the ddoc and index creations before query for better perf.